### PR TITLE
CZSealBody - Seal Stance

### DIFF
--- a/src/gamez/zSeal/seal.cpp
+++ b/src/gamez/zSeal/seal.cpp
@@ -15,6 +15,8 @@ CZSealBody::CZSealBody(zdb::CNode* node, CCharacterType* chartype) : CEntity(ENT
     m_desiredState = SEAL_STATE::stateStand;
     m_desiredPeek = SEAL_PEEK::PEEK_RIGHT;
     
+    m_stance = SEAL_STANCE::STANCE_STAND;
+    
     m_recoilParam = 0.0f;
     m_select = NULL;
 

--- a/src/gamez/zSeal/zseal.h
+++ b/src/gamez/zSeal/zseal.h
@@ -386,6 +386,14 @@ public:
 	void AdrenalineIncr(f32 increase);
 
 	/// -------------------------------------------
+	/// STANCE
+	/// -------------------------------------------
+
+	SEAL_STANCE UpdateStance();	
+	SEAL_STANCE SetStance(SEAL_STANCE stance);
+	SEAL_STANCE GetStance(char flag) const;
+
+	/// -------------------------------------------
 	/// STATE CONDITIONS
 	/// -------------------------------------------
 
@@ -477,6 +485,8 @@ public:
 	CZSealBody* m_cachedReticuleSeal;
 	u32 m_useCachedReticuleSeal : 1;
 	u32 m_unused : 31;
+
+	SEAL_STANCE m_stance;
 
 	bool m_TriggerCount;
 	s32 m_RemoteRoundCount;


### PR DESCRIPTION
# Summary of Changes
This pull request includes changes to the `CZSealBody` class in the `src/gamez/zSeal` files to add and manage the stance of the seal entity. The most important changes include adding a new member variable to track the stance, and implementing methods to update, set, and get the stance.

Changes to `CZSealBody` class:

* [`src/gamez/zSeal/seal.cpp`](diffhunk://#diff-3e3660cc299329bc5f7eea527c6b43ad19199dbb275bef386f13eb2407d42666R18-R19): Initialized the `m_stance` member variable to `SEAL_STANCE::STANCE_STAND` in the `CZSealBody` constructor.
* [`src/gamez/zSeal/zseal.h`](diffhunk://#diff-4f6396eb71768e1db15ad2ea6441baa022e47cf3c56cbf31ddf6cec43c4c92d5R489-R490): Added `m_stance` member variable to the `CZSealBody` class to track the stance of the seal entity.
* [`src/gamez/zSeal/zseal.h`](diffhunk://#diff-4f6396eb71768e1db15ad2ea6441baa022e47cf3c56cbf31ddf6cec43c4c92d5R388-R395): Implemented `UpdateStance`, `SetStance`, and `GetStance` methods to manage the stance of the seal entity.

## DISASSEMBLY
I'm using IDA and ReClass as a means for static and dynamic analysis. I noticed that you did not have these member variables and thought I would share them. 

GetStance -> 0x00288B30
SetStance -> 0x00281E30
UpdateStance -> 0x0025C990

CZSealBody.m_stance = offset 0x304 in the class
![image](https://github.com/user-attachments/assets/59bb7cd5-8872-49de-b5c5-eba3ae8c61ec)

![image](https://github.com/user-attachments/assets/239c93af-55a6-4fb7-b9fb-64f494783e43)
![image](https://github.com/user-attachments/assets/8e2794c6-9b82-4e97-8d74-3a0c8fbdc2a9)
