### PR TITLE
define CZWeapon::SetHasFireMode

### DIFF
--- a/src/gamez/zWeapon/zwep_weapon.cpp
+++ b/src/gamez/zWeapon/zwep_weapon.cpp
@@ -75,14 +75,10 @@ void CZWeapon::AddLegalAmmo(CZAmmo* ammo)
 
 }
 
+// 	RVA: 0x339A60 -> SCUS_971.34
 bool CZWeapon::HasFireMode(s32 id) const
 {
-	if (id < 5)
-	{
-		return m_hasFiremodes[id];
-	}
-
-	return true;
+	return id >= 5 || m_hasFiremodes[id];
 }
 
 void CZWeapon::ClearAnims()
@@ -121,6 +117,15 @@ void CZWeapon::Close()
 void CZWeapon::Fire(CZProjectile& projectile)
 {
 
+}
+
+//	RVA: 0x339A30 -> SCUS_971.34
+void CZWeapon::SetHasFireMode(FIREMODE newMode)
+{
+	m_hasFiremodes[newMode] = true;
+	
+	if (m_maxfiremode < newMode)
+		m_maxfiremode = newMode;
 }
 
 // TODO: Reimplement the zoom function properly


### PR DESCRIPTION
This pull request introduces a new method to the `CZWeapon` class in the `zwep_weapon.cpp` file. The new method, `SetHasFireMode`, allows the setting of a fire mode for the weapon, with a check to ensure the fire mode index is within bounds.

Key changes:

* [`src/gamez/zWeapon/zwep_weapon.cpp`](diffhunk://#diff-2a7b5223cc31fcf9e141c719305a8c71ded1ad26dfc9ad6299f6852ce67a1772R126-R138): Added the `SetHasFireMode(FIREMODE newMode)` method to the `CZWeapon` class, including a boundary check for the fire mode index and updating the `m_maxfiremode` if the new mode exceeds the current maximum.

I verified functionality by setting 9MM pistol firetype to `FIREMODE::BURST`


EDIT:
I've  updated the definition for `CZWeapon::HasFireMode` to better fit the formatting when fully decompiled with imported structures. also included the RVA for further analysis

functions decompiled in ida with a defined struct for CZWeapon
```cpp
bool __fastcall x__CZWeapon::HasFireMode(CZWeapon *this, __int64 id)
{
  return id >= 5 || this->bHasFireMode[id];
}
```

```cpp
void __fastcall x__CZWeapon::SetHasFireMode(CZWeapon *this, EFireMode newMode)
{
  this->bHasFireMode[newMode] = 1;              // m_firemodes
  if ( LOBYTE(this->mMaxFireMode) < newMode )   // m_maxFireMode
    LOBYTE(this->mMaxFireMode) = newMode;
}
```


imported structure obtained via dynamic memory analysis [reference material]
```cpp
struct CZWeapon
{
	char pad_0000[4];	//0x0000
	unsigned int pName;	//0x0004
	unsigned int pNameDesc;	//0x0008
	char pad_000C[4];	//0x000C
	unsigned int pNameIcon;	//0x0010
	unsigned int pNameGear;	//0x0014
	unsigned int pNameModel;	//0x0018
	unsigned int pBulletImpactName;	//0x001C
	EFireMode mMaxFireMode;	//0x0020
	int szMag;	//0x0024
	int defaultMags;	//0x0028
	char pad_002C[8];	//0x002C
	char Encumbrance;	//0x0034
	char pad_0035[3];	//0x0035
	float maxRange;	//0x0038
	float effectiveRange;	//0x003C
	float muzzleVelocity;	//0x0040
	float impactRadius;	//0x0044
	float fireWait;	//0x0048
	char pad_004C[4];	//0x004C
	bool bReloadAfterShot;	//0x0050
	char pad_0051[15];	//0x0051
	char IDtype;	//0x0060
	char pad_0061[3];	//0x0061
	unsigned int pHitAnimations;	//0x0064
	unsigned int pFireAnimations[2];	//0x0068
	unsigned int pDefaultSpecialAnim;	//0x0070
	unsigned int pSpecialMaterialAnim;	//0x0074
	char pad_0078[8];	//0x0078
	unsigned int pNameHitAnim;	//0x0080
	unsigned int pNameFireAnim;	//0x0084
	unsigned int pNameDefaultSpecialAnim;	//0x0088
	unsigned int pNameSpecialMaterial;	//0x008C
	char pad_0090[24];	//0x0090
	bool bHasFireMode[4];	//0x00A8
	char pad_00AC[292];	//0x00AC
};	//Size: 0x01D0
```
