### PR TITLE
Add m_entity member to CNodeEx

### DIFF
--- a/src/gamez/zNode/znode.h
+++ b/src/gamez/zNode/znode.h
@@ -410,6 +410,9 @@ namespace zdb
 		virtual void OnMove(CNode* node) {}
 		virtual void OnSelect(CNode* node, bool selected) {}
 		virtual void OnWeaponHit(CNode* node, IntersectStruct* intersection, CZProjectile* projectile) {}
+
+	public:
+		class CEntity* m_entity;
 	};
 
 	class CModel : public CNode


### PR DESCRIPTION
Introduces a public pointer to CEntity in the CNodeEx class for potential entity access.

<p align="center">
<img src="https://github.com/user-attachments/assets/adcd78fd-8611-44e1-b40b-d74af184a492">
</p>